### PR TITLE
Fixing multiple typesetting issues

### DIFF
--- a/documentation_template_latex/zubaxdoc.cls
+++ b/documentation_template_latex/zubaxdoc.cls
@@ -89,8 +89,8 @@
 \setlist[itemize,4]{leftmargin=4em}
 
 \setlist[description]{leftmargin=\leftskip,labelindent=\dimexpr\leftskip+\parindent\relax}
-\setlist[enumerate]{leftmargin=\leftskip,itemindent=1.4em,nosep}
-\setlist[itemize]{leftmargin=\leftskip,itemindent=1em,nosep}
+\setlist[enumerate]{itemindent=0ex,leftmargin=\leftskip+1.4em,nosep}
+\setlist[itemize]{itemindent=0ex,leftmargin=\leftskip+1em,nosep}
 
 % Continuous footnote numbering
 \counterwithout{footnote}{chapter}
@@ -140,16 +140,16 @@
     \centering\huge\bfseries
 }
 
-\titleformat{\chapter}{\huge\bfseries}{}{1em}{\makebox[17mm][l]{\thechapter}\hangindent=17mm}
-\titleformat{\section}{\Large\bfseries}{}{1em}{\makebox[17mm][l]{\thesection}\hangindent=17mm}
-\titleformat{\subsection}{\bfseries}{}{1em}{\makebox[17mm][l]{\thesubsection}\hangindent=17mm}
+\titleformat{\chapter}{\huge\bfseries}{}{0em}{\makebox[17mm][l]{\thechapter}\hangindent=\leftskip}
+\titleformat{\section}{\Large\bfseries}{}{0em}{\makebox[17mm][l]{\thesection}\hangindent=\leftskip}
+\titleformat{\subsection}{\bfseries}{}{0em}{\makebox[17mm][l]{\thesubsection}\hangindent=\leftskip}
 \titleformat{\subsubsection}{\itshape}{\thesubsubsection}{1em}{%
     \makebox[17mm][l]{\thesubsubsection}\hangindent=17mm
 }
 
 % Starred sections
-\titleformat{name=\chapter,numberless}{\huge\bfseries}{}{1em}{}
-\titleformat{name=\section,numberless}{\Large\bfseries}{}{1em}{}
+\titleformat{name=\chapter,numberless}{\huge\bfseries}{}{0em}{}
+\titleformat{name=\section,numberless}{\Large\bfseries}{}{0em}{}
 
 % {left}{before}{after}[right]
 \titlespacing{\chapter}{0em}{0em}{0em}
@@ -234,8 +234,8 @@
 % Use this wrapper environment to define tables in it.
 % This environment provides proper placement of the table within the page, and the properly positioned caption.
 \newenvironment{ZubaxTableWrapper}[1]{
-    \NoLeftSkip
-    \begin{minipage}{\textwidth}  % Minipage is needed to prevent page breaks after the caption
+%    \NoLeftSkip
+    \begin{minipage}{\textwidth-\leftskip}  % Minipage is needed to prevent page breaks after the caption
         \begin{ThreePartTable}
             % https://tex.stackexchange.com/questions/3243/why-should-a-table-caption-be-placed-above-the-table
             \captionof{table}{#1}
@@ -255,7 +255,7 @@
 
 % Use this environment to define a table within the wrapper environment defined above.
 \newenvironment{ZubaxWrappedTable}[2][\empty]{
-    \NoLeftSkip
+%    \NoLeftSkip
     \begin{tabu} to \textwidth {#2}
         \hline
         \ifx\empty#1\everyrow{\hline}\fi %every row has the border by default


### PR DESCRIPTION
### Issues Addressed
1. Aligned tables with the \leftskip line
2. Aligned title labels with the left margin and titles with \leftskip